### PR TITLE
feat: add admin dashboard and R2 diagnostics

### DIFF
--- a/modules.d.ts
+++ b/modules.d.ts
@@ -2,3 +2,36 @@ declare module "*.toml" {
   const value: any;
   export default value;
 }
+
+declare module '@aws-sdk/client-s3' {
+  interface S3ClientConfig {
+    region?: string;
+    endpoint?: string;
+    credentials?: {
+      accessKeyId: string;
+      secretAccessKey: string;
+    };
+    forcePathStyle?: boolean;
+  }
+
+  export class S3Client {
+    constructor(config: S3ClientConfig);
+    send<T>(command: any): Promise<T>;
+  }
+
+  export class ListObjectsV2Command {
+    constructor(input: Record<string, unknown>);
+  }
+
+  export class PutObjectCommand {
+    constructor(input: Record<string, unknown>);
+  }
+
+  export class GetObjectCommand {
+    constructor(input: Record<string, unknown>);
+  }
+
+  export class DeleteObjectCommand {
+    constructor(input: Record<string, unknown>);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@astrojs/mdx": "^4.2.0",
     "@astrojs/sitemap": "^3.2.1",
     "@astrojs/vue": "^5.0.7",
+    "@aws-sdk/client-s3": "^3.668.0",
     "@fontsource-variable/dm-sans": "^5.2.5",
     "@fontsource-variable/eb-garamond": "^5.2.5",
     "@fontsource-variable/gabarito": "^5.2.5",

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,0 +1,27 @@
+---
+const { class: className = '' } = Astro.props as { class?: string };
+---
+<div class={`admin-card ${className}`.trim()}>
+  <slot />
+</div>
+<style>
+  .admin-card {
+    background: var(--card-bg, #fff);
+    border: 1px solid #111;
+    border-radius: 0;
+    padding: 1.5rem;
+    box-shadow: 0 8px 0 rgba(0, 0, 0, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .admin-card {
+      --card-bg: #111;
+      color: #f5f5f5;
+      border-color: #f5f5f5;
+      box-shadow: 0 8px 0 rgba(245, 245, 245, 0.08);
+    }
+  }
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,20 @@
 /// <reference path="../.astro/types.d.ts" />
+
+interface ImportMetaEnv {
+  readonly MODE: string;
+  readonly PROD: boolean;
+  readonly DEV: boolean;
+  readonly ADMIN_PASSWORD: string;
+  readonly R2_ACCOUNT_ID: string;
+  readonly R2_BUCKET: string;
+  readonly R2_S3_ENDPOINT: string;
+  readonly R2_ACCESS_KEY_ID: string;
+  readonly R2_SECRET_ACCESS_KEY: string;
+  readonly R2_S3_FORCE_PATH_STYLE?: string;
+  readonly TYPESENSE_HOST?: string;
+  readonly TYPESENSE_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -1,0 +1,65 @@
+import { S3Client } from '@aws-sdk/client-s3';
+
+interface R2Config {
+  accountId: string;
+  bucket: string;
+  endpoint: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  forcePathStyle: boolean;
+}
+
+let client: S3Client | null = null;
+let cachedConfig: R2Config | null = null;
+
+function ensureConfig(): R2Config {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
+
+  const accountId = import.meta.env.R2_ACCOUNT_ID;
+  const bucket = import.meta.env.R2_BUCKET;
+  const endpoint = import.meta.env.R2_S3_ENDPOINT;
+  const accessKeyId = import.meta.env.R2_ACCESS_KEY_ID;
+  const secretAccessKey = import.meta.env.R2_SECRET_ACCESS_KEY;
+  const forcePathStyle = (import.meta.env.R2_S3_FORCE_PATH_STYLE ?? '').toLowerCase() === 'true';
+
+  if (!accountId || !bucket || !endpoint || !accessKeyId || !secretAccessKey) {
+    throw new Error('Missing R2 environment variables.');
+  }
+
+  cachedConfig = {
+    accountId,
+    bucket,
+    endpoint,
+    accessKeyId,
+    secretAccessKey,
+    forcePathStyle,
+  };
+
+  return cachedConfig;
+}
+
+export function getR2Client(): S3Client {
+  if (client) {
+    return client;
+  }
+
+  const config = ensureConfig();
+
+  client = new S3Client({
+    region: 'auto',
+    endpoint: config.endpoint,
+    credentials: {
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    },
+    forcePathStyle: config.forcePathStyle,
+  });
+
+  return client;
+}
+
+export function getR2Bucket(): string {
+  return ensureConfig().bucket;
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,88 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { AstroCookies } from 'astro';
+
+const SESSION_COOKIE = 'admin_session';
+const SESSION_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+interface AdminSession {
+  isAdmin: true;
+}
+
+function getSecret(): string {
+  const secret = import.meta.env.ADMIN_PASSWORD;
+  if (!secret) {
+    throw new Error('ADMIN_PASSWORD env var is not set.');
+  }
+
+  return secret;
+}
+
+function signPayload(payload: string): string {
+  const secret = getSecret();
+  return createHmac('sha256', secret).update(payload).digest('base64url');
+}
+
+function encodeSession(data: AdminSession): string {
+  const payload = JSON.stringify(data);
+  const signature = signPayload(payload);
+  const combined = `${payload}.${signature}`;
+  return Buffer.from(combined, 'utf8').toString('base64url');
+}
+
+function decodeSession(raw: string): AdminSession | null {
+  try {
+    const decoded = Buffer.from(raw, 'base64url').toString('utf8');
+    const separator = decoded.lastIndexOf('.');
+    if (separator === -1) {
+      return null;
+    }
+
+    const payload = decoded.slice(0, separator);
+    const providedSignature = decoded.slice(separator + 1);
+    const expectedSignature = signPayload(payload);
+
+    const providedBuffer = Buffer.from(providedSignature, 'utf8');
+    const expectedBuffer = Buffer.from(expectedSignature, 'utf8');
+
+    if (providedBuffer.length !== expectedBuffer.length) {
+      return null;
+    }
+
+    if (!timingSafeEqual(providedBuffer, expectedBuffer)) {
+      return null;
+    }
+
+    const parsed = JSON.parse(payload) as AdminSession;
+    if (parsed?.isAdmin === true) {
+      return { isAdmin: true };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export function setAdminSession(cookies: AstroCookies): void {
+  const value = encodeSession({ isAdmin: true });
+  cookies.set(SESSION_COOKIE, value, {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: Boolean(import.meta.env.PROD),
+    maxAge: SESSION_TTL_SECONDS,
+  });
+}
+
+export function getAdminSession(cookies: AstroCookies): AdminSession | null {
+  const cookie = cookies.get(SESSION_COOKIE);
+  if (!cookie?.value) {
+    return null;
+  }
+
+  return decodeSession(cookie.value);
+}
+
+export function clearAdminSession(cookies: AstroCookies): void {
+  cookies.delete(SESSION_COOKIE, { path: '/' });
+}

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,0 +1,523 @@
+---
+import Card from '../../components/Card.astro';
+import { getAdminSession } from '../../lib/session';
+
+export const prerender = false;
+
+const session = getAdminSession(Astro.cookies);
+if (!session?.isAdmin) {
+  return Astro.redirect('/admin/login');
+}
+
+const typesenseReady = Boolean(
+  import.meta.env.TYPESENSE_HOST && import.meta.env.TYPESENSE_API_KEY,
+);
+const r2Bucket = import.meta.env.R2_BUCKET ?? '';
+const r2Endpoint = import.meta.env.R2_S3_ENDPOINT ?? '';
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Dashboard</title>
+  </head>
+  <body class="admin-page">
+    <main class="shell">
+      <header class="page-header">
+        <h1>Admin Dashboard</h1>
+        <p class="tagline">Tools for keeping the catalog humming.</p>
+      </header>
+      <section class="stack">
+        <Card class="access-card">
+          <div class="access-row">
+            <div class="access-text">
+              <h2>Access</h2>
+              <p>Signed in as Admin.</p>
+            </div>
+            <form method="post" action="/admin/logout">
+              <button type="submit" class="secondary">Log out</button>
+            </form>
+          </div>
+        </Card>
+        <Card>
+          <div class="card-heading">
+            <div>
+              <h2>Access Connections</h2>
+              <p class="muted">Run these when something looks off.</p>
+            </div>
+            <a href="#" data-run-all class="run-all">Run all tests</a>
+          </div>
+          <div class="button-row">
+            <button id="test-r2" class="primary" data-service="r2" type="button">Test Cloudflare R2</button>
+            <button
+              id="test-typesense"
+              class="secondary"
+              disabled={!typesenseReady}
+              title={typesenseReady ? undefined : 'Coming soon'}
+              type="button"
+            >Test Typesense</button>
+          </div>
+          <dl class="env-list">
+            <div>
+              <dt>R2 Bucket</dt>
+              <dd>{r2Bucket || '—'}</dd>
+            </div>
+            <div>
+              <dt>R2 Endpoint</dt>
+              <dd>{r2Endpoint || '—'}</dd>
+            </div>
+          </dl>
+          <div class="log-block">
+            <h3>Recent results</h3>
+            <ul data-log></ul>
+            <p class="log-hint">Latest results appear on top. Only the last 10 are kept.</p>
+          </div>
+        </Card>
+      </section>
+    </main>
+    <script type="module" is:inline>
+      const logs = [];
+      const maxLogs = 10;
+      const logList = document.querySelector('[data-log]');
+      const r2Button = document.getElementById('test-r2');
+      const runAllLink = document.querySelector('[data-run-all]');
+      const typesenseButton = document.getElementById('test-typesense');
+
+      const renderLogs = () => {
+        if (!logList) return;
+        logList.innerHTML = '';
+        for (const entry of logs) {
+          const li = document.createElement('li');
+          li.className = 'log-entry';
+
+          const status = document.createElement('span');
+          status.className = 'status';
+          status.setAttribute('aria-hidden', 'true');
+          status.textContent = entry.ok ? '✅' : '❌';
+
+          const timeEl = document.createElement('time');
+          timeEl.dateTime = entry.timestampISO;
+          timeEl.textContent = entry.timestamp;
+
+          const message = document.createElement('span');
+          message.className = 'message';
+          message.textContent = entry.message;
+
+          const duration = document.createElement('span');
+          duration.className = 'duration';
+          duration.textContent = entry.duration ?? '';
+
+          li.append(status, timeEl, message, duration);
+          logList.appendChild(li);
+        }
+      };
+
+      const pushLog = (entry) => {
+        logs.unshift(entry);
+        if (logs.length > maxLogs) {
+          logs.pop();
+        }
+        renderLogs();
+      };
+
+      const formatMs = (ms) => `${ms} ms`;
+
+      const runR2Test = async () => {
+        if (!r2Button) return;
+        const originalLabel = r2Button.textContent;
+        r2Button.textContent = 'Testing…';
+        r2Button.disabled = true;
+        try {
+          const response = await fetch('/api/test-r2');
+          const data = await response.json();
+          const now = new Date();
+          const entryBase = {
+            timestamp: now.toLocaleTimeString(),
+            timestampISO: now.toISOString(),
+          };
+          if (response.ok && data?.ok) {
+            pushLog({
+              ok: true,
+              ...entryBase,
+              message: 'R2: PASS',
+              duration: formatMs(data.totalMs ?? 0),
+            });
+          } else {
+            pushLog({
+              ok: false,
+              ...entryBase,
+              message: `R2: FAIL — ${data?.failedStep ?? 'unknown'}: ${data?.error ?? 'error'}`,
+              duration: '',
+            });
+          }
+        } catch (error) {
+          const now = new Date();
+          pushLog({
+            ok: false,
+            timestamp: now.toLocaleTimeString(),
+            timestampISO: now.toISOString(),
+            message: `R2: FAIL — ${error instanceof Error ? error.message : 'Unknown error'}`,
+            duration: '',
+          });
+        } finally {
+          r2Button.disabled = false;
+          r2Button.textContent = originalLabel ?? 'Test Cloudflare R2';
+        }
+      };
+
+      const runTypesenseTest = async () => {
+        if (!typesenseButton || typesenseButton.disabled) return;
+        const originalLabel = typesenseButton.textContent;
+        typesenseButton.textContent = 'Testing…';
+        typesenseButton.disabled = true;
+        try {
+          const response = await fetch('/api/test-typesense');
+          const data = await response.json().catch(() => ({}));
+          const now = new Date();
+          const entryBase = {
+            timestamp: now.toLocaleTimeString(),
+            timestampISO: now.toISOString(),
+          };
+          if (response.ok && data?.ok) {
+            pushLog({
+              ok: true,
+              ...entryBase,
+              message: 'Typesense: PASS',
+              duration: formatMs(data.totalMs ?? 0),
+            });
+          } else {
+            const errorLabel = data?.error ? `: ${data.error}` : '';
+            pushLog({
+              ok: false,
+              ...entryBase,
+              message: `Typesense: FAIL — ${data?.failedStep ?? 'pending'}${errorLabel}`,
+              duration: '',
+            });
+          }
+        } catch (error) {
+          const now = new Date();
+          pushLog({
+            ok: false,
+            timestamp: now.toLocaleTimeString(),
+            timestampISO: now.toISOString(),
+            message: `Typesense: FAIL — ${error instanceof Error ? error.message : 'Unknown error'}`,
+            duration: '',
+          });
+        } finally {
+          typesenseButton.textContent = originalLabel ?? 'Test Typesense';
+          typesenseButton.disabled = false;
+        }
+      };
+
+      r2Button?.addEventListener('click', () => {
+        if (r2Button.dataset.cooldown === 'true') {
+          return;
+        }
+
+        runR2Test();
+        r2Button.dataset.cooldown = 'true';
+        setTimeout(() => {
+          if (r2Button) {
+            delete r2Button.dataset.cooldown;
+          }
+        }, 5000);
+      });
+
+      runAllLink?.addEventListener('click', (event) => {
+        event.preventDefault();
+        runR2Test();
+        runTypesenseTest();
+      });
+
+      typesenseButton?.addEventListener('click', (event) => {
+        event.preventDefault();
+        runTypesenseTest();
+      });
+    </script>
+  </body>
+</html>
+<style>
+  :global(body) {
+    margin: 0;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: #fafafa;
+    color: #111;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global(body) {
+      background: #050505;
+      color: #f5f5f5;
+    }
+  }
+
+  .admin-page {
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    padding: 3rem 1.5rem 4rem;
+  }
+
+  .shell {
+    width: min(960px, 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .page-header h1 {
+    margin: 0 0 0.35rem;
+    font-size: clamp(1.75rem, 2.4vw, 2.4rem);
+  }
+
+  .tagline {
+    margin: 0;
+    color: #555;
+    font-size: 1rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .tagline {
+      color: #ccc;
+    }
+  }
+
+  .stack {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .access-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .access-text h2 {
+    margin: 0 0 0.35rem;
+    font-size: 1.35rem;
+  }
+
+  .access-text p {
+    margin: 0;
+    color: #555;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .access-text p {
+      color: #ccc;
+    }
+  }
+
+  .button-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  button.primary,
+  button.secondary,
+  .secondary {
+    border: 1px solid #111;
+    border-radius: 0;
+    padding: 0.6rem 1.4rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    background: transparent;
+    color: inherit;
+  }
+
+  button.primary {
+    background: #111;
+    color: #fff;
+  }
+
+  button.primary[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  button.secondary,
+  .secondary {
+    background: #fff;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    button.primary {
+      background: #f5f5f5;
+      color: #050505;
+      border-color: #f5f5f5;
+    }
+
+    button.secondary,
+    .secondary {
+      background: #111;
+      color: #f5f5f5;
+      border-color: #f5f5f5;
+    }
+  }
+
+  button.secondary[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .card-heading {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .card-heading h2 {
+    margin: 0;
+    font-size: 1.35rem;
+  }
+
+  .muted {
+    margin: 0.25rem 0 0;
+    color: #555;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .muted {
+      color: #ccc;
+    }
+  }
+
+  .run-all {
+    font-size: 0.9rem;
+    text-decoration: underline;
+    color: inherit;
+  }
+
+  .run-all:focus {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+
+  .env-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+  }
+
+  .env-list div {
+    border: 1px solid #111;
+    border-radius: 0;
+    padding: 0.75rem;
+    background: rgba(255, 255, 255, 0.6);
+  }
+
+  .env-list dt {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin: 0 0 0.4rem;
+    color: #555;
+  }
+
+  .env-list dd {
+    margin: 0;
+    font-weight: 600;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .env-list div {
+      background: rgba(17, 17, 17, 0.6);
+      border-color: #f5f5f5;
+    }
+
+    .env-list dt {
+      color: #aaa;
+    }
+  }
+
+  .log-block {
+    border: 1px solid #111;
+    padding: 1rem;
+    border-radius: 0;
+    background: rgba(255, 255, 255, 0.8);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .log-block h3 {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  .log-block ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .log-entry {
+    display: grid;
+    grid-template-columns: auto auto 1fr auto;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.9rem;
+  }
+
+  .log-entry time {
+    font-variant-numeric: tabular-nums;
+    color: #555;
+  }
+
+  .log-entry .message {
+    font-weight: 600;
+  }
+
+  .log-entry .duration {
+    color: #555;
+  }
+
+  .log-hint {
+    margin: 0;
+    font-size: 0.75rem;
+    color: #777;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .log-block {
+      background: rgba(17, 17, 17, 0.85);
+      border-color: #f5f5f5;
+    }
+
+    .log-entry time,
+    .log-entry .duration,
+    .log-hint {
+      color: #bbb;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .admin-page {
+      padding: 2rem 1rem 3rem;
+    }
+
+    .log-entry {
+      grid-template-columns: auto 1fr;
+      grid-template-rows: auto auto;
+    }
+
+    .log-entry time {
+      grid-column: 1 / -1;
+    }
+
+    .log-entry .duration {
+      justify-self: end;
+    }
+  }
+</style>

--- a/src/pages/admin/login.astro
+++ b/src/pages/admin/login.astro
@@ -1,0 +1,174 @@
+---
+import Card from '../../components/Card.astro';
+import { getAdminSession, setAdminSession } from '../../lib/session';
+
+export const prerender = false;
+
+const session = getAdminSession(Astro.cookies);
+if (session?.isAdmin) {
+  return Astro.redirect('/admin');
+}
+
+let error: string | null = null;
+
+if (Astro.request.method === 'POST') {
+  const formData = await Astro.request.formData();
+  const password = formData.get('password');
+  const adminPassword = import.meta.env.ADMIN_PASSWORD;
+
+  if (typeof password === 'string' && password === adminPassword) {
+    setAdminSession(Astro.cookies);
+    return Astro.redirect('/admin');
+  }
+
+  error = 'Incorrect password. Please try again.';
+}
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Login</title>
+  </head>
+  <body class="admin-body">
+    <main class="admin-container">
+      <Card>
+        <header class="card-header">
+          <h1>Admin Access</h1>
+          <p class="subtitle">Enter the passphrase to access the dashboard.</p>
+        </header>
+        <form method="post" class="form-stack">
+          <label class="field">
+            <span>Password</span>
+            <input
+              type="password"
+              name="password"
+              autocomplete="current-password"
+              required
+              autofocus
+            />
+          </label>
+          {error && <p class="error">{error}</p>}
+          <button type="submit" class="primary">Sign in</button>
+        </form>
+      </Card>
+    </main>
+  </body>
+</html>
+<style>
+  :global(body) {
+    margin: 0;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: #fafafa;
+    color: #111;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :global(body) {
+      background: #050505;
+      color: #f5f5f5;
+    }
+  }
+
+  .admin-body {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+  }
+
+  .admin-container {
+    width: min(400px, 100%);
+  }
+
+  .card-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .subtitle {
+    margin: 0;
+    color: #555;
+    font-size: 0.95rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .subtitle {
+      color: #ccc;
+    }
+  }
+
+  .form-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  .field input {
+    border: 1px solid #111;
+    border-radius: 0;
+    padding: 0.75rem 0.85rem;
+    font-size: 1rem;
+    background: #fff;
+    color: inherit;
+  }
+
+  .field input:focus {
+    outline: 2px solid #111;
+    outline-offset: 2px;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .field input {
+      background: #111;
+      border-color: #f5f5f5;
+      color: #f5f5f5;
+    }
+
+    .field input:focus {
+      outline-color: #f5f5f5;
+    }
+  }
+
+  .primary {
+    align-self: flex-start;
+    border: 1px solid #111;
+    border-radius: 0;
+    background: #111;
+    color: #fff;
+    padding: 0.65rem 1.5rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    letter-spacing: 0.02em;
+  }
+
+  .primary:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .primary {
+      background: #f5f5f5;
+      color: #050505;
+      border-color: #f5f5f5;
+    }
+  }
+
+  .error {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #b00020;
+  }
+</style>

--- a/src/pages/admin/logout.astro
+++ b/src/pages/admin/logout.astro
@@ -1,0 +1,8 @@
+---
+import { clearAdminSession } from '../../lib/session';
+
+export const prerender = false;
+
+clearAdminSession(Astro.cookies);
+return Astro.redirect('/admin/login');
+---

--- a/src/pages/api/test-r2.ts
+++ b/src/pages/api/test-r2.ts
@@ -1,0 +1,169 @@
+import type { APIRoute } from 'astro';
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3';
+import { performance } from 'node:perf_hooks';
+
+import { getR2Bucket, getR2Client } from '../../lib/r2';
+
+interface StepResult {
+  name: 'list' | 'put' | 'get' | 'del';
+  ok: boolean;
+  ms: number;
+  error?: string;
+}
+
+const MAX_KEY_LENGTH = 64;
+
+function createDiagKey(): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const key = `diag/ping-${timestamp}.json`;
+  return key.length > MAX_KEY_LENGTH ? `diag/ping-${Date.now()}.json` : key;
+}
+
+function createFailureResponse(step: StepResult['name'], error: unknown): Response {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  const body = JSON.stringify({
+    service: 'r2',
+    ok: false,
+    error: message,
+    failedStep: step,
+    timestamp: new Date().toISOString(),
+  });
+
+  return new Response(body, {
+    status: 500,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+async function streamToString(body: unknown): Promise<string> {
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  if (body && typeof (body as any).transformToString === 'function') {
+    return (body as any).transformToString();
+  }
+
+  const chunks: Uint8Array[] = [];
+  const readable = body as NodeJS.ReadableStream;
+
+  for await (const chunk of readable) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+export const GET: APIRoute = async () => {
+  const client = getR2Client();
+  const bucket = getR2Bucket();
+  const steps: StepResult[] = [];
+  const key = createDiagKey();
+  let objectCreated = false;
+
+  const runStep = async (
+    name: StepResult['name'],
+    operation: () => Promise<void>,
+  ): Promise<void> => {
+    const start = performance.now();
+    try {
+      await operation();
+      steps.push({ name, ok: true, ms: Math.round(performance.now() - start) });
+    } catch (error) {
+      const elapsed = Math.round(performance.now() - start);
+      steps.push({ name, ok: false, ms: elapsed, error: error instanceof Error ? error.message : 'Unknown error' });
+      throw { step: name, error };
+    }
+  };
+
+  try {
+    await runStep('list', async () => {
+      await client.send(
+        new ListObjectsV2Command({
+          Bucket: bucket,
+          Prefix: 'diag/',
+          MaxKeys: 1,
+        }),
+      );
+    });
+
+    const diagBody = JSON.stringify({ ok: true, t: new Date().toISOString() });
+
+    await runStep('put', async () => {
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: diagBody,
+          ContentType: 'application/json',
+        }),
+      );
+      objectCreated = true;
+    });
+
+    await runStep('get', async () => {
+      const getResult = await client.send(
+        new GetObjectCommand({
+          Bucket: bucket,
+          Key: key,
+        }),
+      );
+      const bodyStream = (getResult as { Body?: unknown }).Body;
+      if (!bodyStream) {
+        throw new Error('Empty response body');
+      }
+      const body = await streamToString(bodyStream);
+      JSON.parse(body);
+    });
+
+    await runStep('del', async () => {
+      await client.send(
+        new DeleteObjectCommand({
+          Bucket: bucket,
+          Key: key,
+        }),
+      );
+    });
+
+    const totalMs = steps.reduce((sum, step) => sum + step.ms, 0);
+    const bodyJson = JSON.stringify({
+      service: 'r2',
+      ok: true,
+      steps,
+      totalMs,
+      timestamp: new Date().toISOString(),
+    });
+
+    return new Response(bodyJson, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (caught) {
+    if (objectCreated) {
+      try {
+        await client.send(
+          new DeleteObjectCommand({
+            Bucket: bucket,
+            Key: key,
+          }),
+        );
+      } catch {
+        // ignore cleanup failures
+      }
+    }
+    const step = (caught as { step?: StepResult['name'] }).step ?? 'list';
+    const error = (caught as { error?: unknown }).error ?? caught;
+    return createFailureResponse(step, error);
+  }
+};

--- a/src/pages/api/test-typesense.ts
+++ b/src/pages/api/test-typesense.ts
@@ -1,0 +1,20 @@
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async () => {
+  return new Response(
+    JSON.stringify({
+      service: 'typesense',
+      ok: false,
+      error: 'Typesense diagnostics not implemented yet.',
+      failedStep: 'pending',
+      timestamp: new Date().toISOString(),
+    }),
+    {
+      status: 501,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    },
+  );
+};


### PR DESCRIPTION
## Summary
- implement session helpers and login/logout flows for the admin area
- add the /admin dashboard with access controls and connection testing UI
- create the Cloudflare R2 diagnostics API along with a placeholder Typesense endpoint

## Testing
- pnpm astro check

------
https://chatgpt.com/codex/tasks/task_e_68e2d40dda048323af15aac0e84f8840