### PR TITLE
Ensure Vercel serverless bundle includes dependencies

### DIFF
--- a/vendor/astrojs-vercel/serverless.js
+++ b/vendor/astrojs-vercel/serverless.js
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 
 const entrypoint = new URL('./serverless/entrypoint.mjs', import.meta.url);
@@ -51,6 +52,73 @@ function vercelServerlessIntegration(options = {}) {
         }
         if (existsSync(serverDir)) {
           cpSync(serverDir, functionDir, { recursive: true });
+        }
+
+        const packageJsonSrc = join(projectRoot, 'package.json');
+        const packageJsonDest = join(functionDir, 'package.json');
+        if (existsSync(packageJsonSrc)) {
+          cpSync(packageJsonSrc, packageJsonDest);
+        } else {
+          logger.warn('vercel', 'No package.json found in project root; serverless function will not contain dependencies.');
+        }
+
+        const lockFiles = ['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock'];
+        let copiedLockfile = '';
+        for (const lock of lockFiles) {
+          const src = join(projectRoot, lock);
+          if (existsSync(src)) {
+            cpSync(src, join(functionDir, lock));
+            copiedLockfile = lock;
+            break;
+          }
+        }
+
+        const installDependencies = () => {
+          if (!existsSync(packageJsonDest)) {
+            return;
+          }
+
+          const installCommands = [
+            {
+              command: 'pnpm',
+              args: ['install', '--prod', '--ignore-scripts', '--frozen-lockfile'],
+              condition: () => copiedLockfile === 'pnpm-lock.yaml'
+            },
+            {
+              command: 'yarn',
+              args: ['install', '--production', '--ignore-scripts'],
+              condition: () => copiedLockfile === 'yarn.lock'
+            },
+            {
+              command: 'npm',
+              args: ['install', '--omit=dev', '--ignore-scripts'],
+              condition: () => true
+            }
+          ];
+
+          const { command, args } = installCommands.find(({ condition }) => condition());
+          logger.info('vercel', `Installing serverless function dependencies using ${command}...`);
+          const result = spawnSync(command, args, {
+            cwd: functionDir,
+            stdio: 'inherit'
+          });
+
+          if (result.error) {
+            throw result.error;
+          }
+
+          if (result.status !== 0) {
+            throw new Error(`Failed to install serverless function dependencies with ${command}.`);
+          }
+        };
+
+        installDependencies();
+
+        const astroModuleDir = join(functionDir, 'node_modules', 'astro');
+        if (!existsSync(astroModuleDir)) {
+          throw new Error(
+            'Serverless function is missing the Astro runtime. Ensure dependencies are installed correctly.'
+          );
         }
 
         const manifestFile = readdirSync(functionDir).find((file) => file.startsWith('manifest_') && file.endsWith('.mjs'));


### PR DESCRIPTION
## Summary
- copy the project package manifest and lockfile into the generated Vercel function directory
- install production dependencies inside the function output so SSR runtime imports resolve at execution time
- fail the build if the Astro runtime is missing after dependency installation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3973c2bb083239cb76535b88f2a91